### PR TITLE
Adding .gitattributes file to focus on C#/F#

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 *.css linguist-detectable=false
 *.scss linguist-detectable=false
-*.js linguist-detectable=true
+*.js linguist-detectable=false
 *.java linguist-detectable=false
-*.html linguist-detectable=true
+*.html linguist-detectable=false
 *.javascript linguist-detectable=false
 *.ipynb linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.css linguist-detectable=false
+*.scss linguist-detectable=false
+*.js linguist-detectable=true
+*.java linguist-detectable=false
+*.html linguist-detectable=true
+*.javascript linguist-detectable=false
+*.ipynb linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 *.css linguist-detectable=false
-*.cs linguist-detectable=false
 *.scss linguist-detectable=false
 *.js linguist-detectable=false
 *.java linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 *.css linguist-detectable=false
+*.cs linguist-detectable=false
 *.scss linguist-detectable=false
 *.js linguist-detectable=false
 *.java linguist-detectable=false


### PR DESCRIPTION
I just cloned this repo and noticed that it shows more "javascript" than anything else (happens with my R projects that target the web). So I added a .gitattributes file that masks all of the linguist detection for those ancillary file types. With this in the repo the project shows up with F# and C# and that's it. 😊 (below is the before and after in my clone of your repo)
![Screenshot 2021-03-04 154913](https://user-images.githubusercontent.com/8174976/110047649-1c69c600-7d03-11eb-85c0-050807bc332b.png)
![Screenshot 2021-03-04 154932](https://user-images.githubusercontent.com/8174976/110047657-1f64b680-7d03-11eb-85d6-419cc9220c68.png)

